### PR TITLE
Hotfix coffeescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cli-color": "~1.1.0",
     "coffee-cache": "1.0.2",
-    "coffee-script": "1.10.0",
+    "coffee-script": "1.11.1",
     "finalhandler": "^0.5.0",
     "flowhub-registry": "0.0.3",
     "handlebars": "^4.0.5",


### PR DESCRIPTION
Older version of coffeescript with Node Argon was missing the `lib/coffee-script/register` module. Newer version of coffeescript lacks the .npmignore that was keeping it from being pulled down during `npm install`